### PR TITLE
Улучшение tcp сервера

### DIFF
--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -1,6 +1,8 @@
 ﻿using MemoryCache.Tcp;
 
-TcpServer tcpServer = new();
-await tcpServer.StartAsync();
+var sourceToken = new CancellationTokenSource();
+
+TcpServer tcpServer = new("127.0.0.1", 8080);
+await tcpServer.StartAsync(sourceToken.Token);
 
 Console.ReadLine();


### PR DESCRIPTION
1. Socket лучше оборачивать в using (или await using с NetworkStream) или хотя бы держать в try/finally. Сейчас при ошибке в StartAsync он может не освободиться.
2. Каждый цикл у тебя арендуется новый массив из пула (Rent внутри while). Это плохо для производительности. Лучше арендовать один буфер на клиента и переиспользовать его.
3. Добавить try/catch вокруг ProcessClientAsync, чтобы сервер не падал при ошибках парсинга или сетевых сбоях.
4. Во всех асинхронных методах стоит использовать CancellationToken
5. ip адрес и порт лучше принимать через конструктор